### PR TITLE
Add json option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ by specifying `restart.txt` as the filename:
 - **`options.delimiter`** - *string*  
     Separator between hashsum and filename.
     Default: `  ` (two spaces)
+
+- **`options.json`** - *string*  
+    Write JSON file with filenames as keys, hashes as values.
+    Default: `false`

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function hashsum(options) {
 		dest: process.cwd(),
 		hash: 'sha1',
 		force: false,
-		delimiter: '  '
+		delimiter: '  ',
+		json: false
 	});
 	options = _.defaults(options, { filename: options.hash.toUpperCase() + 'SUMS' });
 
@@ -57,10 +58,17 @@ function hashsum(options) {
 	}
 
 	function writeSums() {
-		var lines = _.keys(hashes).sort().map(function (key) {
-			return hashes[key] + options.delimiter + key + '\n';
-		});
-		var data = new Buffer(lines.join(''));
+		var contents;
+		if(options.json) {
+			contents = JSON.stringify(hashes);
+		}
+		else {
+			var lines = _.keys(hashes).sort().map(function (key) {
+				return hashes[key] + options.delimiter + key + '\n';
+			});
+			contents = lines.join('');
+		}
+		var data = new Buffer(contents);
 
 		if (options.force || !fs.existsSync(hashesFilePath) || compareBuffer(fs.readFileSync(hashesFilePath), data) !== 0) {
 			mkdirp(path.dirname(hashesFilePath));

--- a/test/test.js
+++ b/test/test.js
@@ -298,4 +298,26 @@ describe('gulp-hashsum', function () {
 		expect(function () { stream.write(file); }).to.Throw();
 		done();
 	});
+
+	it('should generate JSON when option is set', function (done) {
+		var files = ['/dir1/file1', '/dir1/file2'];
+		var stream = hashsum({
+			json: true
+		});
+
+		stream.on('end', function () {
+			var data = fs.readFileSync(path.resolve(process.cwd(), 'SHA1SUMS')).toString();
+			var json;
+			try {
+				json = JSON.parse(data);
+			}
+			catch (exception) {
+				json = null;
+			}
+			expect(_.isObject(json)).to.equal(true);
+			done();
+		});
+
+		streamFiles(stream, files);
+	});
 });


### PR DESCRIPTION
Hi, I added an option to generate a JSON that is mapped by filenames.

This is handy for for instance adding a cache-busting query string to css / js imports.

Cheers, Joris