### PR TITLE
gulp-util is deprecated #6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,5 @@
 extends: ./node_modules/eslint-config-remko/eslintrc
+env:
+  node: true
 rules:
   no-var: 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,12 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.8
+    - node_js: "6.12"
+      env:
+        - CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ after_script:
 - rm -rf ./coverage
 matrix:
   include:
-    - node_js: "0.10"
     - node_js: "4.1"
       env:
         - CXX=g++-4.8
@@ -26,6 +25,15 @@ matrix:
           packages:
             - g++-4.8
     - node_js: "6.12"
+      env:
+        - CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+    - node_js: "8"
       env:
         - CXX=g++-4.8
       addons:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var crypto = require('crypto');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var _ = require('lodash');
 var mkdirp = require('mkdirp');
 var slash = require('slash');
@@ -11,21 +11,21 @@ var fs = require('fs');
 var path = require('path');
 
 var compareBuffer = typeof Buffer.compare !== 'undefined' 
-		? Buffer.compare 
-		: function (a, b) {
-			// Naive implementation of Buffer comparison for older 
-			// Node versions. Doesn't follow the same spec as 
-			// Buffer.compare, but we're only interested in equality.
-			if (a.length !== b.length) {
+	? Buffer.compare 
+	: function (a, b) {
+		// Naive implementation of Buffer comparison for older 
+		// Node versions. Doesn't follow the same spec as 
+		// Buffer.compare, but we're only interested in equality.
+		if (a.length !== b.length) {
+			return -1;
+		}
+		for (var i = 0; i < a.length; i++) {
+			if (a[i] !== b[i]) {
 				return -1;
 			}
-			for (var i = 0; i < a.length; i++) {
-				if (a[i] !== b[i]) {
-					return -1;
-				}
-			}
-			return 0;
-		};
+		}
+		return 0;
+	};
 
 function hashsum(options) {
 	options = _.defaults(options || {}, {
@@ -45,7 +45,7 @@ function hashsum(options) {
 			return;
 		}
 		if (file.isStream()) {
-			this.emit('error', new gutil.PluginError('gulp-hashsum', 'Streams not supported'));
+			this.emit('error', new PluginError('gulp-hashsum', 'Streams not supported'));
 			return;
 		}
 		var filePath = path.resolve(options.dest, file.path);

--- a/package.json
+++ b/package.json
@@ -25,21 +25,22 @@
     "coverage": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha"
   },
   "dependencies": {
-    "gulp-util": "~2.2.6",
-    "lodash": "~2.4.1",
+    "lodash": "~4.17.5",
     "mkdirp": "~0.5.0",
-    "slash": "~0.1.1",
-    "through": "~2.3.4"
+    "plugin-error": "~1.0.1",
+    "slash": "~1.0.0",
+    "through": "~2.3.4",
+    "vinyl": "~2.1.0"
   },
   "devDependencies": {
-    "chai": "~1.9.1",
-    "eslint": "^1.10.1",
-    "eslint-config-remko": "^1.0.8",
-    "ghooks": "^0.3.0",
-    "istanbul": "~0.3.0",
-    "mocha": "~1.21.4",
-    "mock-fs": "~3.6.0",
-    "sleep": "~1.1.8"
+    "chai": "~4.1.2",
+    "eslint": "^4.19.0",
+    "eslint-config-remko": "^2.0.3",
+    "ghooks": "^2.0.2",
+    "istanbul": "~0.4.5",
+    "mocha": "~5.0.4",
+    "mock-fs": "~4.4.2",
+    "sleep": "~5.1.1"
   },
   "config": {
     "ghooks": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "mkdirp": "~0.5.0",
     "plugin-error": "~1.0.1",
     "slash": "~1.0.0",
-    "through": "~2.3.4",
-    "vinyl": "~2.1.0"
+    "through": "~2.3.4"
   },
   "devDependencies": {
     "chai": "~4.1.2",
@@ -40,7 +39,8 @@
     "istanbul": "~0.4.5",
     "mocha": "~5.0.4",
     "mock-fs": "~4.4.2",
-    "sleep": "~5.1.1"
+    "sleep": "~5.1.1",
+    "vinyl": "~2.1.0"
   },
   "config": {
     "ghooks": {

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@
 var mock = require('mock-fs');
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var expect = require('chai').expect;
 var sleep = require('sleep');
 var hashsum = require('../index.js');
@@ -14,7 +14,7 @@ var _ = require('lodash');
 describe('gulp-hashsum', function () {
 	function streamFiles(stream, files) {
 		files.forEach(function (file) {
-			stream.write(new gutil.File({
+			stream.write(new Vinyl({
 				contents: fs.readFileSync(file),
 				path: path.resolve(file)
 			}));
@@ -285,7 +285,7 @@ describe('gulp-hashsum', function () {
 			done();
 		});
 
-		stream.write(new gutil.File({contents: null, path: '/dir1/foo'}));
+		stream.write(new Vinyl({contents: null, path: '/dir1/foo'}));
 		stream.end();
 	});
 
@@ -294,7 +294,7 @@ describe('gulp-hashsum', function () {
 	it('should not accept streams', function (done) {
 		var stream = hashsum({dest: '/dir1', force: true});
 
-		var file = new gutil.File({ contents: fs.createReadStream('/dir1/file1'), path: '/dir1/file1' });
+		var file = new Vinyl({ contents: fs.createReadStream('/dir1/file1'), path: '/dir1/file1' });
 		expect(function () { stream.write(file); }).to.Throw();
 		done();
 	});


### PR DESCRIPTION
Updated project and tests to the following:

`gulp-utils.File` has been replaced by `vinyl` per gulp migration instructions
`gulp-utils.PluginError` has been replaced by `plugin-error` per gulp migration instructions

Added a `node 6.12` test to travis

Updated all outdated dependencies due to tests completely failing on node 6+. Tests now succeed in Node 6.12.

Some space reformatting because eslint was complaining (added env node because it didn't know `require` was global).

Not sure if the updated packages will still run on the older versions of Node, I will have to wait to see if travis succeeds on the PR.